### PR TITLE
Add Paymob billing configuration and payment UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Payment gateway (Paymob) configuration
+PAYMOB_SECRET_KEY=your_paymob_secret_key
+PAYMOB_PUBLIC_KEY=your_paymob_public_key
+PAYMOB_INTEGRATION_ID_CAPTURE=your_paymob_capture_integration_id
+PAYMOB_INTEGRATION_ID_USD=your_paymob_usd_integration_id
+PAYMOB_BASE_URL=https://accept.paymob.com/v1
+# Optional: USD is recommended to match subscription pricing
+PAYMOB_DEFAULT_CURRENCY=USD

--- a/client/src/components/payments/payment-brand-strip.tsx
+++ b/client/src/components/payments/payment-brand-strip.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@/lib/utils";
+
+const brandStyles = {
+  visa: {
+    bg: "bg-gradient-to-r from-blue-700 to-blue-500",
+    text: "VISA",
+  },
+  mastercard: {
+    bg: "bg-gradient-to-r from-orange-500 to-red-600",
+    text: "Mastercard",
+  },
+  amex: {
+    bg: "bg-gradient-to-r from-cyan-600 to-blue-500",
+    text: "AmEx",
+  },
+} as const;
+
+const BrandBadge = ({
+  name,
+  className,
+}: {
+  name: keyof typeof brandStyles;
+  className?: string;
+}) => {
+  const style = brandStyles[name];
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-md px-3 py-1 text-sm font-semibold text-white shadow-sm",
+        style.bg,
+        className,
+      )}
+    >
+      <span className="inline-block h-2.5 w-2.5 rounded-full bg-white/80" aria-hidden />
+      <span>{style.text}</span>
+    </div>
+  );
+};
+
+export function PaymentBrandStrip({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex flex-wrap items-center gap-3", className)}>
+      <BrandBadge name="visa" />
+      <BrandBadge name="mastercard" />
+      <BrandBadge name="amex" />
+    </div>
+  );
+}

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -7,6 +7,7 @@ import { Header } from "@/components/layout/header";
 import { useAuth } from "@/hooks/use-auth";
 import { useToast } from "@/hooks/use-toast";
 import { useTheme } from "@/components/theme-provider";
+import { apiRequest } from "@/lib/queryClient";
 
 import {
   Card,
@@ -41,6 +42,10 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PaymentBrandStrip } from "@/components/payments/payment-brand-strip";
 
 // Schema for profile settings form
 const profileFormSchema = z.object({
@@ -67,11 +72,24 @@ type ProfileFormValues = z.infer<typeof profileFormSchema>;
 type NotificationFormValues = z.infer<typeof notificationFormSchema>;
 type AppearanceFormValues = z.infer<typeof appearanceFormSchema>;
 
+type PaymentConfig = {
+  baseUrl: string;
+  publicKey: string;
+  integrationIdCapture: string;
+  integrationIdUsd: string;
+  currency: string;
+  supportedCurrencies: string[];
+};
+
 export default function Settings() {
   const [sidebarVisible, setSidebarVisible] = useState(true);
   const { user } = useAuth();
   const { toast } = useToast();
   const { theme, setTheme } = useTheme();
+  const [paymentConfig, setPaymentConfig] = useState<PaymentConfig | null>(null);
+  const [preferredCurrency, setPreferredCurrency] = useState<string | undefined>(undefined);
+  const [paymentLoading, setPaymentLoading] = useState(false);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
 
   const toggleSidebar = () => {
     setSidebarVisible(!sidebarVisible);
@@ -132,6 +150,51 @@ export default function Settings() {
     });
   };
 
+  useEffect(() => {
+    let isActive = true;
+
+    const fetchPaymentConfig = async () => {
+      setPaymentLoading(true);
+      setPaymentError(null);
+
+      try {
+        const query = preferredCurrency ? `?currency=${preferredCurrency}` : "";
+        const response = await apiRequest("GET", `/api/payment/config${query}`);
+        const data: PaymentConfig = await response.json();
+
+        if (!isActive) return;
+        setPaymentConfig(data);
+
+        if (!preferredCurrency && data.currency) {
+          setPreferredCurrency(data.currency);
+        }
+      } catch (error) {
+        if (!isActive) return;
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unable to load payment settings. Please verify your Paymob credentials.";
+
+        setPaymentError(message);
+        toast({
+          title: "Payment settings unavailable",
+          description: message,
+          variant: "destructive",
+        });
+      } finally {
+        if (isActive) {
+          setPaymentLoading(false);
+        }
+      }
+    };
+
+    fetchPaymentConfig();
+
+    return () => {
+      isActive = false;
+    };
+  }, [preferredCurrency, toast]);
+
   return (
     <div className="min-h-screen flex">
       {/* Sidebar */}
@@ -151,10 +214,11 @@ export default function Settings() {
 
           {/* Settings Tabs */}
           <Tabs defaultValue="profile" className="max-w-4xl">
-            <TabsList className="grid w-full grid-cols-3">
+            <TabsList className="grid w-full grid-cols-4">
               <TabsTrigger value="profile">Profile</TabsTrigger>
               <TabsTrigger value="notifications">Notifications</TabsTrigger>
               <TabsTrigger value="appearance">Appearance</TabsTrigger>
+              <TabsTrigger value="billing">Billing</TabsTrigger>
             </TabsList>
 
             {/* Profile Settings */}
@@ -386,6 +450,117 @@ export default function Settings() {
                     </form>
                   </Form>
                 </CardContent>
+              </Card>
+            </TabsContent>
+
+            {/* Billing & Payment Settings */}
+            <TabsContent value="billing">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Billing & Payments</CardTitle>
+                  <CardDescription>
+                    Align your checkout UI with Paymob and surface USD pricing for subscriptions.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-gray-800">Accepted cards</p>
+                      <p className="text-sm text-gray-600">
+                        Updated Visa and Mastercard styling keeps the payment strip crisp and legible.
+                      </p>
+                    </div>
+                    <PaymentBrandStrip />
+                  </div>
+
+                  <Separator />
+
+                  <div className="grid gap-6 md:grid-cols-2">
+                    <div className="space-y-3">
+                      <div>
+                        <p className="text-sm font-medium text-gray-800">Subscription currency</p>
+                        <p className="text-sm text-gray-600">
+                          Users will see prices in {paymentConfig?.currency ?? "USD"} based on your Paymob integration.
+                        </p>
+                      </div>
+                      <Select
+                        value={preferredCurrency ?? paymentConfig?.currency ?? "USD"}
+                        onValueChange={setPreferredCurrency}
+                        disabled={paymentLoading || !paymentConfig}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select currency" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(paymentConfig?.supportedCurrencies || ["USD"]).map((currency) => (
+                            <SelectItem key={currency} value={currency}>
+                              {currency}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <p className="text-xs text-gray-500">
+                        Currency preference is shared with the API without exposing your Paymob secret key.
+                      </p>
+                    </div>
+
+                    <div className="space-y-3 rounded-lg border bg-white p-4 shadow-sm">
+                      <div className="flex items-center justify-between">
+                        <p className="text-sm font-medium text-gray-800">Gateway configuration</p>
+                        <Badge variant="outline">USD-first</Badge>
+                      </div>
+
+                      {paymentLoading ? (
+                        <div className="space-y-2">
+                          <Skeleton className="h-4 w-32" />
+                          <Skeleton className="h-4 w-40" />
+                          <Skeleton className="h-4 w-28" />
+                        </div>
+                      ) : paymentConfig ? (
+                        <div className="space-y-3 text-sm text-gray-700">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-gray-600">Gateway URL</span>
+                            <code className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-800">
+                              {paymentConfig.baseUrl}
+                            </code>
+                          </div>
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-gray-600">Public key</span>
+                            <code className="max-w-[220px] truncate rounded bg-gray-100 px-2 py-1 text-xs text-gray-800">
+                              {paymentConfig.publicKey}
+                            </code>
+                          </div>
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-gray-600">Capture integration</span>
+                            <code className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-800">
+                              {paymentConfig.integrationIdCapture}
+                            </code>
+                          </div>
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-gray-600">USD integration</span>
+                            <code className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-800">
+                              {paymentConfig.integrationIdUsd}
+                            </code>
+                          </div>
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-gray-600">Displayed currency</span>
+                            <Badge>{paymentConfig.currency}</Badge>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="text-sm text-red-600">
+                          {paymentError ?? "Payment configuration is not available yet."}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+                <CardFooter className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <p className="text-sm text-gray-600">
+                    Paymob environment variables are read from server-side secrets and never exposed to the browser.
+                  </p>
+                  <Badge variant="secondary">Secure checkout ready</Badge>
+                </CardFooter>
               </Card>
             </TabsContent>
           </Tabs>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,6 +21,7 @@ import {
 } from "@shared/schema";
 import { setupAuth } from "./auth";
 import OpenAI from "openai";
+import { getPaymobPublicConfig } from "./services/paymob-config";
 
 // Fallback risk generation when AI is unavailable
 function generateFallbackRisks(description: string, industry?: string): any[] {
@@ -110,7 +111,24 @@ function generateFallbackRisks(description: string, industry?: string): any[] {
 export async function registerRoutes(app: Express): Promise<Server> {
   // Authentication removed - direct access granted
   // const { requireAuth, requireRole } = setupAuth(app);
-  
+
+  // Payment configuration route
+  app.get("/api/payment/config", async (req, res) => {
+    try {
+      const preferredCurrency = typeof req.query.currency === "string"
+        ? req.query.currency
+        : undefined;
+
+      const config = getPaymobPublicConfig(preferredCurrency);
+      res.status(200).json(config);
+    } catch (error) {
+      console.error("Failed to load Paymob configuration:", error);
+      res.status(500).json({
+        message: "Payment configuration is unavailable. Please verify server secrets.",
+      });
+    }
+  });
+
   // User routes
   app.get("/api/users", async (req, res) => {
     try {

--- a/server/services/paymob-config.ts
+++ b/server/services/paymob-config.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+const paymobEnvSchema = z.object({
+  PAYMOB_SECRET_KEY: z.string().min(1, { message: "PAYMOB_SECRET_KEY is required" }),
+  PAYMOB_PUBLIC_KEY: z.string().min(1, { message: "PAYMOB_PUBLIC_KEY is required" }),
+  PAYMOB_INTEGRATION_ID_CAPTURE: z.string().min(1, { message: "PAYMOB_INTEGRATION_ID_CAPTURE is required" }),
+  PAYMOB_INTEGRATION_ID_USD: z.string().min(1, { message: "PAYMOB_INTEGRATION_ID_USD is required" }),
+  PAYMOB_BASE_URL: z.string().url({ message: "PAYMOB_BASE_URL must be a valid URL" }),
+  PAYMOB_DEFAULT_CURRENCY: z.string().optional(),
+});
+
+const SUPPORTED_CURRENCIES = ["USD", "EGP"] as const;
+
+function normalizeCurrency(input?: string) {
+  const normalized = input?.toUpperCase();
+  return SUPPORTED_CURRENCIES.includes(normalized as typeof SUPPORTED_CURRENCIES[number])
+    ? (normalized as typeof SUPPORTED_CURRENCIES[number])
+    : null;
+}
+
+export type PaymobEnv = ReturnType<typeof getPaymobEnv>;
+
+export function getPaymobEnv() {
+  const result = paymobEnvSchema.safeParse(process.env);
+
+  if (!result.success) {
+    const errors = result.error.flatten().fieldErrors;
+    throw new Error(`Invalid Paymob configuration: ${JSON.stringify(errors)}`);
+  }
+
+  const { PAYMOB_DEFAULT_CURRENCY, ...env } = result.data;
+  const currency = normalizeCurrency(PAYMOB_DEFAULT_CURRENCY) ?? "USD";
+
+  return {
+    ...env,
+    currency,
+    supportedCurrencies: SUPPORTED_CURRENCIES,
+  } as const;
+}
+
+export function getPaymobPublicConfig(preferredCurrency?: string) {
+  const env = getPaymobEnv();
+  const currency = normalizeCurrency(preferredCurrency) ?? env.currency;
+
+  return {
+    baseUrl: env.PAYMOB_BASE_URL,
+    publicKey: env.PAYMOB_PUBLIC_KEY,
+    integrationIdCapture: env.PAYMOB_INTEGRATION_ID_CAPTURE,
+    integrationIdUsd: env.PAYMOB_INTEGRATION_ID_USD,
+    currency,
+    supportedCurrencies: env.supportedCurrencies,
+  } as const;
+}
+
+export function getPaymobSecretKey() {
+  const env = getPaymobEnv();
+  return env.PAYMOB_SECRET_KEY;
+}


### PR DESCRIPTION
## Summary
- add validated Paymob configuration loader and expose a sanitized payment config endpoint
- extend settings with a billing tab that surfaces card branding and USD currency selection
- document Paymob gateway environment variables in an example env file

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16608e0c8323962be5217383f667)